### PR TITLE
feat: create new uploadFile function to make it easier to upload files

### DIFF
--- a/src/resources/v1/files/README.md
+++ b/src/resources/v1/files/README.md
@@ -1,0 +1,36 @@
+### File Uploading
+
+The client provides an easy way to upload media files to Magic Hour's cloud storage. Once uploaded, files receive a unique path that can be referenced across other Magic Hour API endpoints.
+
+```typescript
+import Client from "magic-hour";
+import * as fs from "fs";
+import * as path from "path";
+
+const client = new Client({token: process.env["API_TOKEN"]!!});
+
+async function uploadExamples() {
+  try {
+    // Upload from file path
+    const imagePath = await client.v1.files.uploadFile("/path/to/image.jpg");
+    console.log(`Uploaded image: ${imagePath}`);
+
+    // Upload from readable stream
+    const videoStream = fs.createReadStream("./assets/video.mp4");
+    const videoPath = await client.v1.files.uploadFile(videoStream);
+    console.log(`Uploaded video: ${videoPath}`);
+
+    // Use uploaded files in other API endpoints
+    const result = await client.v1.aiImageUpscaler.create({
+      assets: {imageFilePath: imagePath},
+      style: {upscaleFactor: 2},
+    });
+
+    console.log(`Upscaled image: ${result.videoPath}`);
+  } catch (error) {
+    console.error("Upload failed:", error);
+  }
+}
+
+uploadExamples();
+```

--- a/src/resources/v1/files/resource-client.ts
+++ b/src/resources/v1/files/resource-client.ts
@@ -80,31 +80,6 @@ function processFileInput(file: FileInput): {
   }
 }
 
-/**
- * Read file content for upload, handling both file paths and file-like objects.
- */
-function prepareFileForUpload(filePath?: string, fileData?: Buffer | Readable | File): Buffer {
-  if (filePath) {
-    return fs.readFileSync(filePath);
-  } else if (fileData) {
-    if (Buffer.isBuffer(fileData)) {
-      return fileData;
-    } else if (fileData instanceof Readable) {
-      // For streams, we need to read the entire content
-      const chunks: Buffer[] = [];
-      return new Promise<Buffer>((resolve, reject) => {
-        fileData.on("data", (chunk) => chunks.push(chunk));
-        fileData.on("end", () => resolve(Buffer.concat(chunks)));
-        fileData.on("error", reject);
-      }) as any; // This needs to be handled async, but keeping sync for now
-    } else if (typeof File !== "undefined" && fileData instanceof File) {
-      // File object - need to read as buffer
-      return fileData.arrayBuffer().then((ab) => Buffer.from(ab)) as any;
-    }
-  }
-  throw new Error("Invalid file data");
-}
-
 export class FilesClient extends CoreResourceClient {
   private _uploadUrlsLazy?: UploadUrlsClient; // lazy-loading cache
 

--- a/src/resources/v1/files/resource-client.ts
+++ b/src/resources/v1/files/resource-client.ts
@@ -1,9 +1,109 @@
-import {
-  CoreClient,
-  CoreResourceClient,
-  ResourceClientOptions,
-} from "magic-hour/core";
-import { UploadUrlsClient } from "magic-hour/resources/v1/files/upload-urls";
+import {CoreClient, CoreResourceClient, ResourceClientOptions, RUNTIME} from "magic-hour/core";
+import {UploadUrlsClient} from "magic-hour/resources/v1/files/upload-urls";
+import {V1FilesUploadUrlsCreateBodyItemsItem} from "magic-hour/types/v1-files-upload-urls-create-body-items-item";
+import * as fs from "fs";
+import * as path from "path";
+import {Readable} from "stream";
+
+export type FileInput = string | Buffer | Readable | File | NodeJS.ReadableStream;
+
+/**
+ * Determine file type and extension from file path or name.
+ */
+function getFileTypeAndExtension(fileName: string): {
+  fileType: "audio" | "image" | "video";
+  extension: string;
+} {
+  const ext = path.extname(fileName).toLowerCase().slice(1); // Remove the leading dot
+
+  // Video extensions
+  const videoExts = ["mp4", "m4v", "mov", "webm"];
+  // Audio extensions
+  const audioExts = ["mp3", "mpeg", "wav", "aac", "aiff", "flac"];
+  // Image extensions
+  const imageExts = ["png", "jpg", "jpeg", "webp", "avif", "jp2", "tiff", "bmp"];
+
+  let fileType: "audio" | "image" | "video";
+  if (videoExts.includes(ext)) {
+    fileType = "video";
+  } else if (audioExts.includes(ext)) {
+    fileType = "audio";
+  } else if (imageExts.includes(ext)) {
+    fileType = "image";
+  } else {
+    throw new Error(
+      `Unsupported file extension: ${ext}. ` +
+        "Supported types: video (mp4, m4v, mov, webm), " +
+        "audio (mp3, mpeg, wav, aac, aiff, flac), " +
+        "image (png, jpg, jpeg, webp, avif, jp2, tiff, bmp)"
+    );
+  }
+
+  return {fileType, extension: ext};
+}
+
+/**
+ * Process different file input types and return standardized information.
+ */
+function processFileInput(file: FileInput): {
+  filePath?: string;
+  fileData?: Buffer | Readable | File;
+  fileType: "audio" | "image" | "video";
+  extension: string;
+} {
+  if (typeof file === "string") {
+    // File path
+    if (!fs.existsSync(file)) {
+      throw new Error(`File not found: ${file}`);
+    }
+    const {fileType, extension} = getFileTypeAndExtension(file);
+    return {filePath: file, fileType, extension};
+  } else if (Buffer.isBuffer(file)) {
+    throw new Error(
+      "Buffer input requires a file name for extension detection. " +
+        "Please use a file path, File object, or stream with a name property."
+    );
+  } else if (file instanceof Readable) {
+    // Stream with path property
+    const filePath = (file as any).path;
+    if (typeof filePath !== "string") {
+      throw new Error("Stream must have a 'path' property for extension detection.");
+    }
+    const {fileType, extension} = getFileTypeAndExtension(filePath);
+    return {fileData: file, fileType, extension};
+  } else if (typeof File !== "undefined" && file instanceof File) {
+    // File object (browser)
+    const {fileType, extension} = getFileTypeAndExtension(file.name);
+    return {fileData: file, fileType, extension};
+  } else {
+    throw new Error("Unsupported file input type");
+  }
+}
+
+/**
+ * Read file content for upload, handling both file paths and file-like objects.
+ */
+function prepareFileForUpload(filePath?: string, fileData?: Buffer | Readable | File): Buffer {
+  if (filePath) {
+    return fs.readFileSync(filePath);
+  } else if (fileData) {
+    if (Buffer.isBuffer(fileData)) {
+      return fileData;
+    } else if (fileData instanceof Readable) {
+      // For streams, we need to read the entire content
+      const chunks: Buffer[] = [];
+      return new Promise<Buffer>((resolve, reject) => {
+        fileData.on("data", (chunk) => chunks.push(chunk));
+        fileData.on("end", () => resolve(Buffer.concat(chunks)));
+        fileData.on("error", reject);
+      }) as any; // This needs to be handled async, but keeping sync for now
+    } else if (typeof File !== "undefined" && fileData instanceof File) {
+      // File object - need to read as buffer
+      return fileData.arrayBuffer().then((ab) => Buffer.from(ab)) as any;
+    }
+  }
+  throw new Error("Invalid file data");
+}
 
 export class FilesClient extends CoreResourceClient {
   private _uploadUrlsLazy?: UploadUrlsClient; // lazy-loading cache
@@ -14,13 +114,118 @@ export class FilesClient extends CoreResourceClient {
       this.uploadUrls;
     }
   }
+
   get uploadUrls(): UploadUrlsClient {
     return (
       this._uploadUrlsLazy ??
       (this._uploadUrlsLazy = new (require("./upload-urls").UploadUrlsClient)(
         this._client,
-        this._opts,
+        this._opts
       ))
     );
+  }
+
+  /**
+   * Upload a file to Magic Hour's storage.
+   *
+   * This method uploads a file to Magic Hour's secure cloud storage and returns
+   * a file path that can be used as input for other Magic Hour API endpoints.
+   * The file type is automatically detected from the file extension.
+   *
+   * @param file - The file to upload. Can be:
+   *   - **string**: Path to a local file (e.g., "/path/to/image.jpg")
+   *   - **Buffer**: File content as buffer (requires extension detection via other means)
+   *   - **Readable**: Node.js readable stream (must have a 'path' property)
+   *   - **File**: File object (browser environment)
+   *
+   * @returns The uploaded file's path in Magic Hour's storage system.
+   *   This path can be used as input for other API endpoints.
+   *
+   * @throws {Error} If the specified local file doesn't exist.
+   * @throws {Error} If the file type is not supported.
+   * @throws {Error} If the upload request fails (network/server errors).
+   *
+   * @example
+   * ```typescript
+   * import { Client } from "magic-hour";
+   *
+   * const client = new Client({ token: process.env.MAGIC_HOUR_API_TOKEN });
+   *
+   * // Upload from file path
+   * const filePath = await client.v1.files.uploadFile("/path/to/your/image.jpg");
+   * console.log(`Uploaded file: ${filePath}`);
+   *
+   * // Use the uploaded file in other API calls
+   * const result = await client.v1.aiImageUpscaler.create({
+   *   assets: { imageFilePath: filePath },
+   *   style: { upscaleFactor: 2 }
+   * });
+   * ```
+   */
+  async uploadFile(file: FileInput): Promise<string> {
+    const {filePath, fileData, fileType, extension} = processFileInput(file);
+
+    // Create upload URL
+    const response = await this.uploadUrls.create({
+      items: [
+        {
+          extension,
+          type: fileType,
+        },
+      ],
+    });
+
+    if (!response.items || response.items.length === 0) {
+      throw new Error("No upload URL was returned from the server");
+    }
+
+    const uploadInfo = response.items[0];
+    if (!uploadInfo) {
+      throw new Error("Upload info is missing from server response");
+    }
+
+    // Prepare file content
+    let content: Buffer;
+    if (filePath) {
+      content = fs.readFileSync(filePath);
+    } else if (fileData) {
+      if (Buffer.isBuffer(fileData)) {
+        content = fileData;
+      } else if (fileData instanceof Readable) {
+        // For streams, read all data into buffer
+        const chunks: Buffer[] = [];
+        for await (const chunk of fileData) {
+          chunks.push(chunk);
+        }
+        content = Buffer.concat(chunks);
+      } else if (typeof File !== "undefined" && fileData instanceof File) {
+        // File object - convert to buffer
+        const arrayBuffer = await fileData.arrayBuffer();
+        content = Buffer.from(arrayBuffer);
+      } else {
+        throw new Error("Unsupported file data type");
+      }
+    } else {
+      throw new Error("No file data available");
+    }
+
+    // Upload the file
+    const fetcherFn =
+      RUNTIME.type === "node" || typeof fetch !== "function"
+        ? require("node-fetch").default
+        : fetch;
+
+    const uploadResponse = await fetcherFn(uploadInfo.uploadUrl, {
+      method: "PUT",
+      body: content,
+    });
+
+    if (!uploadResponse.ok) {
+      throw new Error(
+        `Upload failed with status ${uploadResponse.status}: ${uploadResponse.statusText}`
+      );
+    }
+
+    return uploadInfo.filePath;
   }
 }

--- a/test/v1-files-upload.test.ts
+++ b/test/v1-files-upload.test.ts
@@ -1,0 +1,413 @@
+import Client, {Environment} from "magic-hour";
+import {Readable} from "stream";
+import * as fs from "fs";
+import * as path from "path";
+
+// Mock fs module
+jest.mock("fs", () => ({
+  existsSync: jest.fn(),
+  readFileSync: jest.fn(),
+}));
+
+const mockFs = fs as jest.Mocked<typeof fs>;
+
+// Mock node-fetch for upload requests
+const mockFetch = jest.fn();
+jest.mock("node-fetch", () => ({
+  default: mockFetch,
+}));
+
+// Mock RUNTIME to ensure we use node-fetch
+jest.mock("magic-hour/core", () => {
+  const actual = jest.requireActual("magic-hour/core");
+  return {
+    ...actual,
+    RUNTIME: {type: "node"},
+  };
+});
+
+describe("FilesClient.uploadFile", () => {
+  let client: Client;
+
+  beforeEach(() => {
+    client = new Client({
+      token: "API_TOKEN",
+      environment: Environment.MockServer,
+    });
+
+    // Reset all mocks
+    jest.clearAllMocks();
+
+    // Setup default fs mocks
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(Buffer.from("mock file content"));
+
+    // Setup default fetch mock for file uploads
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+    });
+  });
+
+  describe("Helper functions", () => {
+    test("getFileTypeAndExtension - should detect video files", () => {
+      // We need to access the helper function through the class instance
+      // Since it's not exported, we'll test it indirectly through uploadFile
+      const videoExtensions = ["mp4", "m4v", "mov", "webm"];
+
+      videoExtensions.forEach(async (ext) => {
+        const mockResponse = {
+          items: [
+            {
+              uploadUrl: "https://example.com/upload",
+              filePath: `test-file.${ext}`,
+              expiresAt: "2024-01-01T00:00:00Z",
+            },
+          ],
+        };
+
+        // Mock the uploadUrls.create method
+        jest.spyOn(client.v1.files.uploadUrls, "create").mockResolvedValue(mockResponse);
+
+        mockFs.existsSync.mockReturnValue(true);
+        mockFs.readFileSync.mockReturnValue(Buffer.from("video content"));
+
+        await expect(client.v1.files.uploadFile(`/path/to/video.${ext}`)).resolves.toBe(
+          `test-file.${ext}`
+        );
+
+        expect(client.v1.files.uploadUrls.create).toHaveBeenCalledWith({
+          items: [{extension: ext, type: "video"}],
+        });
+      });
+    });
+
+    test("getFileTypeAndExtension - should detect audio files", async () => {
+      const audioExtensions = ["mp3", "mpeg", "wav", "aac", "aiff", "flac"];
+
+      for (const ext of audioExtensions) {
+        const mockResponse = {
+          items: [
+            {
+              uploadUrl: "https://example.com/upload",
+              filePath: `test-file.${ext}`,
+              expiresAt: "2024-01-01T00:00:00Z",
+            },
+          ],
+        };
+
+        jest.spyOn(client.v1.files.uploadUrls, "create").mockResolvedValue(mockResponse);
+
+        await expect(client.v1.files.uploadFile(`/path/to/audio.${ext}`)).resolves.toBe(
+          `test-file.${ext}`
+        );
+
+        expect(client.v1.files.uploadUrls.create).toHaveBeenCalledWith({
+          items: [{extension: ext, type: "audio"}],
+        });
+      }
+    });
+
+    test("getFileTypeAndExtension - should detect image files", async () => {
+      const imageExtensions = ["png", "jpg", "jpeg", "webp", "avif", "jp2", "tiff", "bmp"];
+
+      for (const ext of imageExtensions) {
+        const mockResponse = {
+          items: [
+            {
+              uploadUrl: "https://example.com/upload",
+              filePath: `test-file.${ext}`,
+              expiresAt: "2024-01-01T00:00:00Z",
+            },
+          ],
+        };
+
+        jest.spyOn(client.v1.files.uploadUrls, "create").mockResolvedValue(mockResponse);
+
+        await expect(client.v1.files.uploadFile(`/path/to/image.${ext}`)).resolves.toBe(
+          `test-file.${ext}`
+        );
+
+        expect(client.v1.files.uploadUrls.create).toHaveBeenCalledWith({
+          items: [{extension: ext, type: "image"}],
+        });
+      }
+    });
+
+    test("should throw error for unsupported file extension", async () => {
+      await expect(client.v1.files.uploadFile("/path/to/file.xyz")).rejects.toThrow(
+        "Unsupported file extension: xyz"
+      );
+    });
+
+    test("should handle case-insensitive extensions", async () => {
+      const mockResponse = {
+        items: [
+          {
+            uploadUrl: "https://example.com/upload",
+            filePath: "test-file.mp4",
+            expiresAt: "2024-01-01T00:00:00Z",
+          },
+        ],
+      };
+
+      jest.spyOn(client.v1.files.uploadUrls, "create").mockResolvedValue(mockResponse);
+
+      await expect(client.v1.files.uploadFile("/path/to/VIDEO.MP4")).resolves.toBe("test-file.mp4");
+
+      expect(client.v1.files.uploadUrls.create).toHaveBeenCalledWith({
+        items: [{extension: "mp4", type: "video"}],
+      });
+    });
+  });
+
+  describe("File input types", () => {
+    const mockUploadResponse = {
+      items: [
+        {
+          uploadUrl: "https://example.com/upload",
+          filePath: "uploaded-file.jpg",
+          expiresAt: "2024-01-01T00:00:00Z",
+        },
+      ],
+    };
+
+    beforeEach(() => {
+      jest.spyOn(client.v1.files.uploadUrls, "create").mockResolvedValue(mockUploadResponse);
+    });
+
+    test("should handle string file path", async () => {
+      const filePath = "/path/to/image.jpg";
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(Buffer.from("image content"));
+
+      const result = await client.v1.files.uploadFile(filePath);
+
+      expect(result).toBe("uploaded-file.jpg");
+      expect(mockFs.existsSync).toHaveBeenCalledWith(filePath);
+      expect(mockFs.readFileSync).toHaveBeenCalledWith(filePath);
+    });
+
+    test("should throw error if file path does not exist", async () => {
+      mockFs.existsSync.mockReturnValue(false);
+
+      await expect(client.v1.files.uploadFile("/nonexistent/file.jpg")).rejects.toThrow(
+        "File not found: /nonexistent/file.jpg"
+      );
+    });
+
+    test("should handle Buffer input", async () => {
+      const buffer = Buffer.from("image content");
+
+      await expect(client.v1.files.uploadFile(buffer)).rejects.toThrow(
+        "Buffer input requires a file name for extension detection"
+      );
+    });
+
+    test("should handle Readable stream with path property", async () => {
+      const mockStream = new Readable({
+        read() {
+          this.push(Buffer.from("stream content"));
+          this.push(null);
+        },
+      });
+      (mockStream as any).path = "/path/to/video.mp4";
+
+      const result = await client.v1.files.uploadFile(mockStream);
+
+      expect(result).toBe("uploaded-file.jpg");
+      expect(client.v1.files.uploadUrls.create).toHaveBeenCalledWith({
+        items: [{extension: "mp4", type: "video"}],
+      });
+    });
+
+    test("should throw error for stream without path property", async () => {
+      const mockStream = new Readable({
+        read() {
+          this.push(Buffer.from("stream content"));
+          this.push(null);
+        },
+      });
+
+      await expect(client.v1.files.uploadFile(mockStream)).rejects.toThrow(
+        "Stream must have a 'path' property for extension detection"
+      );
+    });
+
+    test.skip("should handle File object (browser)", async () => {
+      // Skipping this test as File object mocking is complex in Node.js environment
+      // This functionality would work in actual browser environments
+    });
+  });
+
+  describe("Upload process", () => {
+    test("should successfully upload file and return file path", async () => {
+      const mockResponse = {
+        items: [
+          {
+            uploadUrl: "https://storage.example.com/upload?token=abc123",
+            filePath: "api-assets/12345/image.jpg",
+            expiresAt: "2024-12-31T23:59:59Z",
+          },
+        ],
+      };
+
+      jest.spyOn(client.v1.files.uploadUrls, "create").mockResolvedValue(mockResponse);
+
+      const result = await client.v1.files.uploadFile("/path/to/image.jpg");
+
+      expect(result).toBe("api-assets/12345/image.jpg");
+      expect(client.v1.files.uploadUrls.create).toHaveBeenCalledWith({
+        items: [{extension: "jpg", type: "image"}],
+      });
+
+      // Verify the PUT request was made
+      expect(mockFetch).toHaveBeenCalledWith("https://storage.example.com/upload?token=abc123", {
+        method: "PUT",
+        body: Buffer.from("mock file content"),
+      });
+    });
+
+    test("should throw error if no upload URL returned", async () => {
+      const mockResponse = {items: []};
+      jest.spyOn(client.v1.files.uploadUrls, "create").mockResolvedValue(mockResponse);
+
+      await expect(client.v1.files.uploadFile("/path/to/image.jpg")).rejects.toThrow(
+        "No upload URL was returned from the server"
+      );
+    });
+
+    test("should throw error if upload info is missing", async () => {
+      const mockResponse = {items: [null]};
+      jest.spyOn(client.v1.files.uploadUrls, "create").mockResolvedValue(mockResponse as any);
+
+      await expect(client.v1.files.uploadFile("/path/to/image.jpg")).rejects.toThrow(
+        "Upload info is missing from server response"
+      );
+    });
+
+    test("should throw error if upload fails", async () => {
+      const mockResponse = {
+        items: [
+          {
+            uploadUrl: "https://storage.example.com/upload",
+            filePath: "api-assets/12345/image.jpg",
+            expiresAt: "2024-12-31T23:59:59Z",
+          },
+        ],
+      };
+
+      jest.spyOn(client.v1.files.uploadUrls, "create").mockResolvedValue(mockResponse);
+
+      // Mock failed upload
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      });
+
+      await expect(client.v1.files.uploadFile("/path/to/image.jpg")).rejects.toThrow(
+        "Upload failed with status 500: Internal Server Error"
+      );
+    });
+  });
+
+  describe("Integration tests", () => {
+    test("should work with actual API response structure", async () => {
+      // Mock a realistic API response
+      const mockResponse = {
+        items: [
+          {
+            uploadUrl: "https://videos.magichour.ai/api-assets/abc123/video.mp4?auth=xyz",
+            filePath: "api-assets/abc123/video.mp4",
+            expiresAt: "2024-07-25T16:56:21.932Z",
+          },
+        ],
+      };
+
+      jest.spyOn(client.v1.files.uploadUrls, "create").mockResolvedValue(mockResponse);
+
+      const testFile = "/tmp/test-video.mp4";
+      const testContent = Buffer.from("fake video content");
+      mockFs.readFileSync.mockReturnValue(testContent);
+
+      const result = await client.v1.files.uploadFile(testFile);
+
+      expect(result).toBe("api-assets/abc123/video.mp4");
+
+      // Verify upload request
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://videos.magichour.ai/api-assets/abc123/video.mp4?auth=xyz",
+        {
+          method: "PUT",
+          body: testContent,
+        }
+      );
+    });
+
+    test("should handle multiple file types in sequence", async () => {
+      const files = [
+        {path: "/path/to/image.png", type: "image", ext: "png"},
+        {path: "/path/to/video.mp4", type: "video", ext: "mp4"},
+        {path: "/path/to/audio.mp3", type: "audio", ext: "mp3"},
+      ];
+
+      for (const file of files) {
+        const mockResponse = {
+          items: [
+            {
+              uploadUrl: `https://storage.example.com/${file.ext}`,
+              filePath: `api-assets/123/${file.path.split("/").pop()}`,
+              expiresAt: "2024-12-31T23:59:59Z",
+            },
+          ],
+        };
+
+        jest.spyOn(client.v1.files.uploadUrls, "create").mockResolvedValue(mockResponse);
+
+        const result = await client.v1.files.uploadFile(file.path);
+
+        expect(result).toBe(`api-assets/123/${file.path.split("/").pop()}`);
+        expect(client.v1.files.uploadUrls.create).toHaveBeenCalledWith({
+          items: [{extension: file.ext, type: file.type}],
+        });
+      }
+    });
+  });
+
+  describe("Error handling", () => {
+    test("should handle network errors during upload URL creation", async () => {
+      jest
+        .spyOn(client.v1.files.uploadUrls, "create")
+        .mockRejectedValue(new Error("Network error"));
+
+      await expect(client.v1.files.uploadFile("/path/to/image.jpg")).rejects.toThrow(
+        "Network error"
+      );
+    });
+
+    test("should handle file read errors", async () => {
+      // Mock upload URLs creation to succeed first
+      const mockResponse = {
+        items: [
+          {
+            uploadUrl: "https://example.com/upload",
+            filePath: "uploaded-file.jpg",
+            expiresAt: "2024-01-01T00:00:00Z",
+          },
+        ],
+      };
+      jest.spyOn(client.v1.files.uploadUrls, "create").mockResolvedValue(mockResponse);
+
+      // Then make file read fail
+      mockFs.readFileSync.mockImplementation(() => {
+        throw new Error("Permission denied");
+      });
+
+      await expect(client.v1.files.uploadFile("/path/to/image.jpg")).rejects.toThrow(
+        "Permission denied"
+      );
+    });
+  });
+});


### PR DESCRIPTION
One of the painpoints of the sdk is file handling. This is just the first step to improve that. The change here is essentially changing from 

```ts
const client = new Client({token: process.env["API_TOKEN"]!!});

const res = await client.v1.files.uploadUrls.create({
  items: [
    { extension: "mp4", type: "video" },
  ],
});

const file = fs.readFileSync("/path/to/file/video.mp4");

await fetch(response.items[0].upload_url, {
  method: "PUT",
  body: file,
});
const file_path = response.items[0].file_path;
```

to 

```ts
const client = new Client({token: process.env["API_TOKEN"]!!});
const filePath = await client.v1.files.uploadFile("/path/to/file/video.mp4");
```