### PR TITLE
ci: refresh Node test matrix (22, 24, 26)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,12 +16,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 20
-          - 21
           - 22
-          - 23
           - 24
-          - 25
+          - 26
     steps:
       #----------------------------------------------
       #  -----  checkout & setup node  -----


### PR DESCRIPTION
## Summary
- Drop EOL Node versions from the test matrix (`20`, `21`, `23`, `25`)
- Keep LTS (`22`, `24`) and add Current (`26`)

## Test plan
- [ ] Confirm CI runs on Node 22, 24, and 26
- [ ] Confirm no jobs remain for dropped versions

Made with [Cursor](https://cursor.com)