### PR TITLE
fix: add official SDK package metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magic-hour",
-  "version": "0.71.0",
+  "version": "0.71.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "magic-hour",
-      "version": "0.71.0",
+      "version": "0.71.1",
       "license": "MIT",
       "dependencies": {
         "make-api-request-js": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-hour",
-  "version": "0.71.0",
+  "version": "0.71.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -47,16 +47,26 @@
   },
   "bugs": "https://github.com/magichourhq/magic-hour-node/issues",
   "description": "Node SDK for Magic Hour API",
-  "homepage": "https://github.com/magichourhq/magic-hour-node",
+  "homepage": "https://docs.magichour.ai/get-started/quick-start",
   "keywords": [
     "magic hour",
+    "generative AI",
     "AI video",
     "AI image",
+    "AI audio",
+    "video generation",
+    "image generation",
+    "audio generation",
+    "text to video",
+    "image to video",
+    "face swap",
+    "lip sync",
+    "SDK",
     "api"
   ],
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/magichourhq/magic-hour-node.git"
+    "url": "https://github.com/magichourhq/magic-hour-node.git"
   }
 }


### PR DESCRIPTION
## Summary

- point the npm package homepage to the Magic Hour Quick Start with Node SDK examples
- use the canonical HTTPS source repository URL
- add focused npm keywords for video, image, and audio generation use cases
- bump the package version from 0.71.0 to 0.71.1

## Why

The published package metadata currently sends developers to GitHub for its homepage, uses a legacy git URL, and exposes only broad search terms. Explicit documentation, source, and capability metadata improve package discovery, establish official ownership, and give developers a direct path to installation and usage examples.

## Developer impact

After 0.71.1 is published, npm and package-aware tools will expose the official Magic Hour Quick Start, source repository, and relevant SDK capabilities.

## Validation

- `npm test` — 36 suites passed, 105 tests passed, 2 skipped
- `npm pack --dry-run` — created the expected `magic-hour@0.71.1` package
- validated the updated homepage and keyword list from package.json
- all configured URLs returned HTTP 200
