### PR TITLE
fix(ci): publish npm package with provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary
- run npm publishing on a GitHub-hosted runner
- keep npm provenance enabled

## Why
The `v0.71.0` and `v0.71.1` publish runs failed because npm only accepts GitHub Actions provenance from GitHub-hosted runners, but the workflow used a Blacksmith self-hosted runner. npm therefore remains on `0.70.0` with stale package metadata, causing Ora to miss the official SDK.

Failed run: https://github.com/magichourhq/magic-hour-node/actions/runs/32222442184

## Verification
- `git diff --check`
- after merge: manually run **Publish to npm**, then verify `npm view magic-hour version repository homepage` reports `0.71.1`, the GitHub repository, and a `magichour.ai` homepage