### PR TITLE
chore: bump SDK to 0.71.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magic-hour",
-  "version": "0.71.1",
+  "version": "0.71.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "magic-hour",
-      "version": "0.71.1",
+      "version": "0.71.2",
       "license": "MIT",
       "dependencies": {
         "make-api-request-js": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-hour",
-  "version": "0.71.1",
+  "version": "0.71.2",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- bump the npm package and lockfile to `0.71.2`

## Why
Creates a fresh release after fixing npm publishing in #189. Merging this PR will create the `v0.71.2` GitHub release, which triggers the corrected npm publish workflow.

## Verification
- `git diff --check`
- confirmed package version, homepage, and repository metadata with `npm pkg get`