### PR TITLE
fix: point SDK homepage to product domain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magic-hour",
-  "version": "0.71.2",
+  "version": "0.71.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "magic-hour",
-      "version": "0.71.2",
+      "version": "0.71.3",
       "license": "MIT",
       "dependencies": {
         "make-api-request-js": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-hour",
-  "version": "0.71.2",
+  "version": "0.71.3",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -47,7 +47,7 @@
   },
   "bugs": "https://github.com/magichourhq/magic-hour-node/issues",
   "description": "Node SDK for Magic Hour API",
-  "homepage": "https://docs.magichour.ai/get-started/quick-start",
+  "homepage": "https://magichour.ai",
   "keywords": [
     "magic hour",
     "generative AI",


### PR DESCRIPTION
orank uses package metadata to associate npm packages with official products. Pointing the SDK homepage at magichour.ai makes that ownership signal explicit and addresses the package discovery gap. Bumps the package patch version to 0.71.3 so the corrected metadata can be published.