### PR TITLE
fix: remove duplicate Face Detection client declaration

### DIFF
--- a/src/resources/v1/face-detection/README.md
+++ b/src/resources/v1/face-detection/README.md
@@ -30,7 +30,6 @@ In addition to the parameters listed in the `create` section below, `generate` i
 import { Client } from "magic-hour";
 
 const client = new Client({ token: process.env["API_TOKEN"]!! });
-const client = new Client({ token: process.env["API_TOKEN"]!! });
 const res = await client.v1.faceDetection.generate(
   {
     assets: { targetFilePath: "/path/to/1234.png" },


### PR DESCRIPTION
## Why

The Face Detection TypeScript example declares `client` twice, so copying the published snippet fails immediately.

## What changed

- remove the duplicate client declaration from the SDK documentation source

## Validation

- `npm run build`
- full Jest suite: 36 suites passed, 105 tests passed, 2 skipped
- `git diff --check`